### PR TITLE
Fix missing brace in add_contact handler

### DIFF
--- a/App/controllers/home.controller.js
+++ b/App/controllers/home.controller.js
@@ -142,6 +142,7 @@ exports.add_contact = (req, res) => {
                     res.send(err);
                 }
                 )
+                }
 
             }else{
                 let data = {


### PR DESCRIPTION
## Summary
- close the if block in the `add_contact` function

## Testing
- `npm test` *(fails: Missing script)*
- `node index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68497c40d9fc8322911e7fcb07051462